### PR TITLE
11.0 caf msm8998

### DIFF
--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -7,10 +7,10 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES := \
     $(TARGET_OUT_HEADERS)/adreno
-LOCAL_C_INCLUDES += $(TARGET_OUT_HEADERS)/qcom/display
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 
 LOCAL_HEADER_LIBRARIES := \
+        display_headers \
         libutils_headers \
         libhardware_headers
 

--- a/libsidebandstreamhandle/Android.mk
+++ b/libsidebandstreamhandle/Android.mk
@@ -6,7 +6,7 @@ LOCAL_SRC_FILES := \
 
 LOCAL_CFLAGS :=
 
-LOCAL_C_INCLUDES:= $(TARGET_OUT_HEADERS)/qcom/display
+LOCAL_HEADER_LIBRARIES := display_headers
 
 LOCAL_SHARED_LIBRARIES := \
   libcutils \

--- a/libstagefrighthw/Android.mk
+++ b/libstagefrighthw/Android.mk
@@ -17,14 +17,6 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-#===============================================================================
-#             Deploy the headers that can be exposed
-#===============================================================================
-
-LOCAL_COPY_HEADERS_TO   := mm-core/omxcore
-LOCAL_COPY_HEADERS      := QComOMXMetadata.h \
-                           QComOMXPlugin.h
-
 LOCAL_SRC_FILES := \
     QComOMXPlugin.cpp                      \
 
@@ -42,8 +34,6 @@ LOCAL_HEADER_LIBRARIES := \
         media_plugin_headers \
         libcutils_headers \
         libutils_headers
-
-LOCAL_C_INCLUDES:= $(TARGET_OUT_HEADERS)/mm-core/omxcore/
 
 LOCAL_SHARED_LIBRARIES :=       \
         libutils                \

--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -63,39 +63,6 @@ OMXCORE_CFLAGS += -D_ANDROID_O_MR1_DIVX_CHANGES
 endif
 
 #===============================================================================
-#             Deploy the headers that can be exposed
-#===============================================================================
-
-LOCAL_COPY_HEADERS_TO   := mm-core/omxcore
-LOCAL_COPY_HEADERS      := inc/OMX_Audio.h
-LOCAL_COPY_HEADERS      += inc/OMX_Component.h
-LOCAL_COPY_HEADERS      += inc/OMX_ContentPipe.h
-LOCAL_COPY_HEADERS      += inc/OMX_Core.h
-LOCAL_COPY_HEADERS      += inc/OMX_Image.h
-LOCAL_COPY_HEADERS      += inc/OMX_Index.h
-LOCAL_COPY_HEADERS      += inc/OMX_IVCommon.h
-LOCAL_COPY_HEADERS      += inc/OMX_Other.h
-LOCAL_COPY_HEADERS      += inc/OMX_QCOMExtns.h
-LOCAL_COPY_HEADERS      += inc/OMX_Types.h
-LOCAL_COPY_HEADERS      += inc/OMX_Video.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_common.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_component.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_msg.h
-LOCAL_COPY_HEADERS      += inc/QOMX_AudioExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_AudioIndexExtensions.h
-LOCAL_COPY_HEADERS      += inc/OMX_CoreExt.h
-LOCAL_COPY_HEADERS      += inc/QOMX_CoreExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_FileFormatExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_IVCommonExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_SourceExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_VideoExtensions.h
-LOCAL_COPY_HEADERS      += inc/OMX_IndexExt.h
-LOCAL_COPY_HEADERS      += inc/OMX_VideoExt.h
-LOCAL_COPY_HEADERS      += inc/QOMX_StreamingExtensions.h
-LOCAL_COPY_HEADERS      += inc/QCMediaDefs.h
-LOCAL_COPY_HEADERS      += inc/QCMetaData.h
-
-#===============================================================================
 #             LIBRARY for Android apps
 #===============================================================================
 

--- a/mm-video-v4l2/vidc/common/Android.mk
+++ b/mm-video-v4l2/vidc/common/Android.mk
@@ -25,7 +25,6 @@ endif
 
 libmm-vidc-inc      := $(LOCAL_PATH)/inc
 libmm-vidc-inc      += $(call project-path-for,qcom-media)/mm-core/inc
-libmm-vidc-inc      += $(TARGET_OUT_HEADERS)/qcom/display
 libmm-vidc-inc      += $(call project-path-for,qcom-media)/libc2dcolorconvert
 libmm-vidc-inc      += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 
@@ -40,7 +39,7 @@ LOCAL_SHARED_LIBRARIES    := liblog libcutils libdl
 
 LOCAL_SRC_FILES   := src/extra_data_handler.cpp
 LOCAL_SRC_FILES   += src/vidc_color_converter.cpp
-LOCAL_HEADER_LIBRARIES := libhardware_headers libutils_headers
+LOCAL_HEADER_LIBRARIES := display_headers libhardware_headers libutils_headers
 
 LOCAL_SRC_FILES   += src/vidc_vendor_extensions.cpp
 

--- a/mm-video-v4l2/vidc/vdec/Android.mk
+++ b/mm-video-v4l2/vidc/vdec/Android.mk
@@ -82,7 +82,6 @@ include $(CLEAR_VARS)
 libmm-vdec-inc          := $(LOCAL_PATH)/inc
 libmm-vdec-inc          += $(call project-path-for,qcom-media)/mm-video-v4l2/vidc/common/inc
 libmm-vdec-inc          += $(call project-path-for,qcom-media)/mm-core/inc
-libmm-vdec-inc          += $(TARGET_OUT_HEADERS)/qcom/display
 libmm-vdec-inc          += $(TARGET_OUT_HEADERS)/adreno
 libmm-vdec-inc          += $(call project-path-for,qcom-media)/libc2dcolorconvert
 libmm-vdec-inc          += $(call project-path-for,qcom-media)/hypv-intercept

--- a/mm-video-v4l2/vidc/venc/Android.mk
+++ b/mm-video-v4l2/vidc/venc/Android.mk
@@ -106,7 +106,6 @@ libmm-venc-inc      := $(LOCAL_PATH)/inc
 libmm-venc-inc      += $(call project-path-for,qcom-media)/mm-video-v4l2/vidc/common/inc
 libmm-venc-inc      += $(call project-path-for,qcom-media)/mm-core/inc
 libmm-venc-inc      += $(call project-path-for,qcom-media)/libstagefrighthw
-libmm-venc-inc      += $(TARGET_OUT_HEADERS)/qcom/display
 libmm-venc-inc      += $(TARGET_OUT_HEADERS)/adreno
 libmm-venc-inc      += $(call project-path-for,qcom-media)/libc2dcolorconvert
 libmm-venc-inc      += $(call project-path-for,qcom-media)/hypv-intercept
@@ -139,6 +138,7 @@ LOCAL_VENDOR_MODULE             := true
 LOCAL_CFLAGS                    := $(libmm-venc-def)
 
 LOCAL_HEADER_LIBRARIES := \
+        display_headers \
         media_plugin_headers \
         libnativebase_headers \
         libcutils_headers \
@@ -180,6 +180,7 @@ LOCAL_VENDOR_MODULE             := true
 LOCAL_CFLAGS                    := $(libmm-venc-def)
 
 LOCAL_HEADER_LIBRARIES := \
+        display_headers \
         media_plugin_headers \
         libnativebase_headers \
         libutils_headers \


### PR DESCRIPTION
LOCAL_COPY_HEADERS is deprecated, so remove all its usages to avoid build warnings.
media: Switch to display_headers lib include needed for build